### PR TITLE
Migrated solution file from VS2010 to VS2017

### DIFF
--- a/src/NClass.sln
+++ b/src/NClass.sln
@@ -1,6 +1,6 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GUI", "GUI\GUI.csproj", "{A2918CE1-6894-4FC9-A864-4651769D0274}"
 	ProjectSection(ProjectDependencies) = postProject
 		{B3B7D798-3D52-47F0-B1A7-A91BC5FE184F} = {B3B7D798-3D52-47F0-B1A7-A91BC5FE184F}


### PR DESCRIPTION
Solution file was appearing as an old VS2010 solution so I updated it to VS2017. I assumed this was OK because the last commit was re-targeting to .NET 4.7.