### PR TITLE
Fixed issue #46: zoom level label displaced in GUI

### DIFF
--- a/src/GUI/MainForm.Designer.cs
+++ b/src/GUI/MainForm.Designer.cs
@@ -969,11 +969,12 @@ namespace NClass.GUI
             // 
             this.toolZoomValue.AutoSize = false;
             this.toolZoomValue.Enabled = false;
+            //this.toolZoomValue.Dock = System.Windows.Forms.DockStyle.Fill;
             this.toolZoomValue.Name = "toolZoomValue";
-            this.toolZoomValue.Font = new System.Drawing.Font(System.Drawing.FontFamily.GenericMonospace, 8);
+            this.toolZoomValue.Font = new System.Drawing.Font(this.Font.FontFamily, 10);
             this.toolZoomValue.Size = new System.Drawing.Size(50, this.standardToolStrip.ClientSize.Height);
             this.toolZoomValue.Text = "100%";
-            this.toolZoomValue.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            this.toolZoomValue.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // toolZoomOut
             // 

--- a/src/GUI/MainForm.Designer.cs
+++ b/src/GUI/MainForm.Designer.cs
@@ -970,7 +970,8 @@ namespace NClass.GUI
             this.toolZoomValue.AutoSize = false;
             this.toolZoomValue.Enabled = false;
             this.toolZoomValue.Name = "toolZoomValue";
-            this.toolZoomValue.Size = new System.Drawing.Size(36, 22);
+            this.toolZoomValue.Font = new System.Drawing.Font(System.Drawing.FontFamily.GenericMonospace, 8);
+            this.toolZoomValue.Size = new System.Drawing.Size(50, this.standardToolStrip.ClientSize.Height);
             this.toolZoomValue.Text = "100%";
             this.toolZoomValue.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 


### PR DESCRIPTION
Fixed the code in `MainForm.Designer.cs` (line #973), so it depends less on the actual size of the zoom used.