### PR TITLE
Improved dialogs

### DIFF
--- a/src/GUI/Dialogs/OptionsDialog.Designer.cs
+++ b/src/GUI/Dialogs/OptionsDialog.Designer.cs
@@ -451,7 +451,6 @@ namespace NClass.GUI.Dialogs
             this.Controls.Add(this.tabOptions);
             this.MaximizeBox = false;
             this.MinimizeBox = false;
-            this.MinimumSize = new System.Drawing.Size(360, 532);
             this.Name = "OptionsDialog";
             this.ShowIcon = false;
             this.ShowInTaskbar = false;
@@ -475,7 +474,8 @@ namespace NClass.GUI.Dialogs
             this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
-
+            //this.MinimumSize = new System.Drawing.Size(360, 532);
+            this.MinimumSize = this.Size;
         }
 
         #endregion

--- a/src/GUI/Dialogs/OptionsDialog.Designer.cs
+++ b/src/GUI/Dialogs/OptionsDialog.Designer.cs
@@ -473,9 +473,7 @@ namespace NClass.GUI.Dialogs
             this.flowLayoutPanel1.ResumeLayout(false);
             this.flowLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
-            //this.MinimumSize = new System.Drawing.Size(360, 532);
-            this.MinimumSize = this.Size;
+            this.PerformLayout();           
         }
 
         #endregion

--- a/src/GUI/Dialogs/OptionsDialog.cs
+++ b/src/GUI/Dialogs/OptionsDialog.cs
@@ -34,6 +34,7 @@ namespace NClass.GUI.Dialogs
         public OptionsDialog()
         {
             InitializeComponent();
+            this.MinimumSize = this.Size;
         }
 
         private void UpdateTexts()

--- a/src/PDFExport/PDFExportOptions.Designer.cs
+++ b/src/PDFExport/PDFExportOptions.Designer.cs
@@ -172,7 +172,7 @@
       // 
       this.cmdCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
       this.cmdCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-      this.cmdCancel.Location = new System.Drawing.Point(205, 189);
+      this.cmdCancel.Location = new System.Drawing.Point(205, 170);
       this.cmdCancel.Name = "cmdCancel";
       this.cmdCancel.Size = new System.Drawing.Size(75, 23);
       this.cmdCancel.TabIndex = 3;
@@ -183,7 +183,7 @@
       // 
       this.cmdOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
       this.cmdOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-      this.cmdOK.Location = new System.Drawing.Point(124, 189);
+      this.cmdOK.Location = new System.Drawing.Point(124, 170);
       this.cmdOK.Name = "cmdOK";
       this.cmdOK.Size = new System.Drawing.Size(75, 23);
       this.cmdOK.TabIndex = 3;

--- a/src/PDFExport/PDFExportOptions.cs
+++ b/src/PDFExport/PDFExportOptions.cs
@@ -44,7 +44,11 @@ namespace PDFExport
     public PDFExportOptions()
     {
       InitializeComponent();
-
+      
+      // Minimum size
+      this.Size = new System.Drawing.Size(370, 270);
+      this.MinimumSize = this.Size;
+      
       LocalizeComponents();
       LoadSettings();
     }


### PR DESCRIPTION
This is a modification of two dialogs that needed more size and better placement.

- OptionsDialog: Needed more size and more minimum size.
- PDFExportOptions: Needed more size and ok/cancel buttons relocation.

![options_dialog](https://user-images.githubusercontent.com/201012/93098918-b1bac480-f6a7-11ea-9207-9a48789cfe0b.png)
![pdf_export_options_dialog](https://user-images.githubusercontent.com/201012/93098922-b2535b00-f6a7-11ea-84bd-94feb078b984.png)

## PDFExportOptions:
- Relocation of buttons was done in the designer (PDFExportOptions.Designer.cs), but the resizing was done in the PDFExportOptions.cs. Anyway, this is compatible with the designer.

## OptionsDialog:

- Resizing was done in the designer. This is probably not compatible with the designer. I'll probably fix this.


