### PR TITLE
Better finished pdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -220,3 +220,6 @@ _Pvt_Extensions
 src/Installer/files/*
 src/GUI/styles
 src/AssemblyImport/libs
+src/lib/*
+src/libs/*
+src/.idea/*

--- a/src/PDFExport/PDFExportFinished.cs
+++ b/src/PDFExport/PDFExportFinished.cs
@@ -15,6 +15,8 @@ namespace PDFExport
     {
       InitializeComponent();
 
+      this.MinimumSize = new Size(450, 125);
+
       LocalizeComponents();
     }
 


### PR DESCRIPTION
The** PDFExport**'s **PDFExportFinishedPDF** dialog was of incorrect size, so the text appeared cut horizontally, and the buttons cut vertically. This simple modification fixes that. It is a correction in size.

I've also added a few tweaks to `.gitignore` in order to ignore the multiple Rider's configuration files.
 