### PR TITLE
Fixed bug where objects inside a package/namespace would corrupt the …

### DIFF
--- a/src/Core/Model.cs
+++ b/src/Core/Model.cs
@@ -274,9 +274,14 @@ namespace NClass.Core
 
                 foreach (var childEntity in ((INestable)entity).NestedChilds)
                 {
-                    var childEntityNode = node.OwnerDocument.CreateElement("ChildEntity");
-                    childEntityNode.InnerText = entities.IndexOf(childEntity).ToString();
-                    child.AppendChild(childEntityNode);
+                    int childEntityIndexNum = entities.IndexOf(childEntity);
+
+                    if (childEntityIndexNum >= 0) // made to rule out any cases where the child entity has an index of -1
+                    {
+                        var childEntityNode = node.OwnerDocument.CreateElement("ChildEntity");
+                        childEntityNode.InnerText = childEntityIndexNum.ToString();
+                        child.AppendChild(childEntityNode);
+                    }
                 }
 
                 containersNode.AppendChild(child);


### PR DESCRIPTION
Objects visually placed inside a package/namespace using NClass, will error, as the serializer converts the index integer of the deleted object to -1, this is fixed by adding an if statement to check if the object's index is -1, and skip over it if it is.

Optionally also delete the parent object (parent entity > child entity) if all child entities have an index of -1, but this will be automated when re-saving.